### PR TITLE
Fix interest calculations.

### DIFF
--- a/sql/_init/2.fix_legacy_loans_after_interest_change.sql
+++ b/sql/_init/2.fix_legacy_loans_after_interest_change.sql
@@ -1,0 +1,19 @@
+UPDATE loan
+SET start_date = '2022-06-17 04:00:01.000000 +00:00'::TIMESTAMP + ('6 HOURS' ::INTERVAL)
+WHERE id = 149;
+UPDATE loan_section
+SET start_date = '2022-06-17 04:00:01.000000 +00:00'::TIMESTAMP + ('6 HOURS' ::INTERVAL)
+WHERE id = '2b477434-1cf5-4dae-b7ae-fba1b0e5998f';
+
+UPDATE loan_section
+SET end_date = NULL
+WHERE id = '121e2b3c-24c5-4b39-be56-898422794392';
+
+UPDATE adjust_loan
+SET amount = 133220
+WHERE id = 102;
+
+UPDATE adjust_loan
+SET amount  = 655,
+    loan_id = 346
+WHERE id = 101;

--- a/sql/simulate/find_bad_balances.sql
+++ b/sql/simulate/find_bad_balances.sql
@@ -12,17 +12,19 @@ FROM client c
                             WHERE c.id = client_id
                             ORDER BY date DESC, event DESC
                             LIMIT 1) > 0) q ON c.id = q.id
-ORDER BY c.balance_invest_last_updated;
+ORDER BY c.balance_invest_last_updated DESC;
 
-SELECT DISTINCT c.id
+SELECT c.*
 FROM client c
-WHERE (SELECT balance
-       FROM client_invest_snapshot
-       WHERE c.id = client_id
-       ORDER BY date DESC, event DESC
-       LIMIT 1) BETWEEN 1 AND 4096 * 30
-   OR (SELECT balance
-       FROM client_loan_snapshot
-       WHERE c.id = client_id
-       ORDER BY date DESC, event DESC
-       LIMIT 1) BETWEEN -1 AND -4096 * 30;
+         RIGHT JOIN(SELECT DISTINCT c.id
+                    FROM client c
+                    WHERE (SELECT balance
+                           FROM client_invest_snapshot
+                           WHERE c.id = client_id
+                           ORDER BY date DESC, event DESC
+                           LIMIT 1) BETWEEN 1 AND 4096 * 30
+                       OR (SELECT balance
+                           FROM client_loan_snapshot
+                           WHERE c.id = client_id
+                           ORDER BY date DESC, event DESC
+                           LIMIT 1) BETWEEN -1 AND -4096 * 30) q ON c.id = q.id;

--- a/sql/simulate/list_snapshots.sql
+++ b/sql/simulate/list_snapshots.sql
@@ -3,15 +3,16 @@ SELECT date,
        COALESCE(loan_balance,
                 FIRST_VALUE(loan_balance)
                 OVER (PARTITION BY loan_grp ORDER BY date,event), 0)
+           / 4096.0
                                AS loan_balance,
        COALESCE(invest_balance,
                 FIRST_VALUE(invest_balance)
                 OVER (PARTITION BY invest_grp ORDER BY date,event ), 0)
+           / 4096.0
                                AS invest_balance,
        q.loan_delta / 4096.0   AS loan_delta,
        q.invest_delta / 4096.0 AS invest_delta,
        event
---/ 262144.0
 FROM (SELECT *,
              COALESCE(SUM(CASE WHEN loan_balance IS NOT NULL THEN 1 END)
                       OVER (ORDER BY date ,event ), 0) AS loan_grp,

--- a/src/main/java/com/ambrosia/loans/database/account/DClientLoanSnapshot.java
+++ b/src/main/java/com/ambrosia/loans/database/account/DClientLoanSnapshot.java
@@ -1,16 +1,38 @@
 package com.ambrosia.loans.database.account;
 
 import com.ambrosia.loans.database.account.base.AccountEventType;
+import com.ambrosia.loans.database.account.loan.DLoan;
+import com.ambrosia.loans.database.account.loan.InterestCheckpoint;
 import com.ambrosia.loans.database.entity.client.DClient;
+import io.ebean.annotation.DbDefault;
 import java.time.Instant;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity
 @Table(name = "client_loan_snapshot")
 public class DClientLoanSnapshot extends DClientSnapshot {
 
-    public DClientLoanSnapshot(DClient client, Instant date, long balance, long delta, AccountEventType event) {
+    @ManyToOne
+    protected DLoan loan;
+    @DbDefault("0")
+    @Column
+    private long principal;
+
+    public DClientLoanSnapshot(InterestCheckpoint checkpoint, DClient client, Instant date, long balance, long delta,
+        AccountEventType event) {
         super(client, date, balance, delta, event);
+        this.loan = checkpoint.getLoan();
+        this.principal = checkpoint.principal().negate().longValue();
+    }
+
+    public long getPrincipal() {
+        return this.principal;
+    }
+
+    public DLoan getLoan() {
+        return loan;
     }
 }

--- a/src/main/java/com/ambrosia/loans/database/account/DClientSnapshot.java
+++ b/src/main/java/com/ambrosia/loans/database/account/DClientSnapshot.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 @MappedSuperclass
 public class DClientSnapshot extends Model implements Comparable<DClientSnapshot> {
 
-    private static final Comparator<DClientSnapshot> COMPARATOR = Comparator.comparing(DClientSnapshot::getDate)
+    public static final Comparator<DClientSnapshot> COMPARATOR = Comparator.comparing(DClientSnapshot::getDate)
         .thenComparing(DClientSnapshot::getEventType, AccountEventType.ORDER);
     @Id
     private UUID id;

--- a/src/main/java/com/ambrosia/loans/database/account/adjust/AdjustApi.java
+++ b/src/main/java/com/ambrosia/loans/database/account/adjust/AdjustApi.java
@@ -36,7 +36,7 @@ public interface AdjustApi {
             loan.refresh();
         }
         if (updateBalance)
-            client.updateBalance(difference.amount(), date, type);
+            client.updateBalance(loan, difference.amount(), date, type);
     }
 
     static DAdjustLoan createAdjustment(DStaffConductor staff, DLoan loan, Emeralds amount, Instant date) {
@@ -47,8 +47,8 @@ public interface AdjustApi {
             transaction.commit();
         }
         AlterCreateApi.create(staff, AlterCreateType.ADJUST_LOAN, adjustment.getId());
-        
-        adjustment.getClient().updateBalance(amount.amount(), date, adjustment.getEventType());
+
+        adjustment.getClient().updateBalance(loan, amount.amount(), date, adjustment.getEventType());
         return adjustment;
     }
 }

--- a/src/main/java/com/ambrosia/loans/database/account/adjust/DAdjustLoan.java
+++ b/src/main/java/com/ambrosia/loans/database/account/adjust/DAdjustLoan.java
@@ -70,6 +70,15 @@ public class DAdjustLoan extends Model implements Commentable, IAccountChange {
         return this.comments;
     }
 
+    public Emeralds getAmount() {
+        return Emeralds.of(amount);
+    }
+
+    @Override
+    public long getId() {
+        return this.id;
+    }
+
     @Override
     public DClient getClient() {
         return this.loan.getClient();
@@ -82,20 +91,11 @@ public class DAdjustLoan extends Model implements Commentable, IAccountChange {
 
     @Override
     public void updateSimulation() {
-        this.getClient().updateBalance(this.amount, this.getDate(), getEventType());
+        this.getClient().updateBalance(this.loan, this.amount, this.getDate(), getEventType());
     }
 
     @Override
     public AccountEventType getEventType() {
         return type;
-    }
-
-    public Emeralds getAmount() {
-        return Emeralds.of(amount);
-    }
-
-    @Override
-    public long getId() {
-        return this.id;
     }
 }

--- a/src/main/java/com/ambrosia/loans/database/account/base/AccountEvent.java
+++ b/src/main/java/com/ambrosia/loans/database/account/base/AccountEvent.java
@@ -49,25 +49,6 @@ public abstract class AccountEvent extends Model implements Commentable, IAccoun
         this(request.getClient(), date, request.getConductor(), request.getAmount(), request.getEventType());
     }
 
-    @Override
-    public Instant getDate() {
-        return this.date.toInstant();
-    }
-
-    public void setDate(Instant value) {
-        this.date = Timestamp.from(value);
-    }
-
-    @Override
-    public void updateSimulation() {
-        this.client.updateBalance(this.amount, this.getDate(), getEventType());
-    }
-
-    @Override
-    public AccountEventType getEventType() {
-        return this.eventType;
-    }
-
     public Emeralds getDeltaAmount() {
         return Emeralds.of(this.amount);
     }
@@ -84,6 +65,25 @@ public abstract class AccountEvent extends Model implements Commentable, IAccoun
     @Override
     public DClient getClient() {
         return client;
+    }
+
+    @Override
+    public Instant getDate() {
+        return this.date.toInstant();
+    }
+
+    public void setDate(Instant value) {
+        this.date = Timestamp.from(value);
+    }
+
+    @Override
+    public void updateSimulation() {
+        this.client.updateBalance(null, this.amount, this.getDate(), getEventType());
+    }
+
+    @Override
+    public AccountEventType getEventType() {
+        return this.eventType;
     }
 
 }

--- a/src/main/java/com/ambrosia/loans/database/account/base/AccountEventApi.java
+++ b/src/main/java/com/ambrosia/loans/database/account/base/AccountEventApi.java
@@ -25,7 +25,7 @@ public interface AccountEventApi {
             investment = new DWithdrawal(client, date, staff, emeralds, type);
 
         try (Transaction transaction = DB.beginTransaction()) {
-            client.updateBalance(emeralds.amount(), date, type, transaction);
+            client.updateBalance(null, emeralds.amount(), date, type, transaction);
             investment.save(transaction);
             transaction.commit();
         }

--- a/src/main/java/com/ambrosia/loans/database/account/loan/HasDateRange.java
+++ b/src/main/java/com/ambrosia/loans/database/account/loan/HasDateRange.java
@@ -20,15 +20,22 @@ public interface HasDateRange {
     }
 
     @NotNull
+    default Instant getEarliestOfEnd(Instant otherEnd) {
+        Instant endDate = getEndDate();
+        if (endDate == null) return otherEnd;
+        if (endDate.isAfter(otherEnd)) return otherEnd;
+        return endDate;
+    }
+
+    @NotNull
     default Instant getEndDateOrNow() {
         return getEndDate(Instant.now());
     }
 
     default Duration getDuration(Instant start, Instant end) {
         Instant startDate = this.getStartDate();
-        Instant endDate = this.getEndDate(end);
         Instant constrainedStart = start.isAfter(startDate) ? start : startDate;
-        Instant constrainedEnd = end.isBefore(endDate) ? end : endDate;
+        Instant constrainedEnd = this.getEarliestOfEnd(end);
         return Duration.between(constrainedStart, constrainedEnd);
     }
 

--- a/src/main/java/com/ambrosia/loans/database/account/loan/InterestCheckpoint.java
+++ b/src/main/java/com/ambrosia/loans/database/account/loan/InterestCheckpoint.java
@@ -1,0 +1,110 @@
+package com.ambrosia.loans.database.account.loan;
+
+import com.ambrosia.loans.database.account.DClientLoanSnapshot;
+import com.ambrosia.loans.util.emerald.Emeralds;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public class InterestCheckpoint {
+
+    private final DLoan loan;
+    private long principal; // positive
+    private long balance; // positive
+    private Instant lastUpdated;
+    private long accumulatedInterest = 0;
+
+    public InterestCheckpoint(DClientLoanSnapshot snapshot) {
+        this.lastUpdated = snapshot.getDate();
+        this.loan = snapshot.getLoan();
+        this.principal = -snapshot.getPrincipal();
+        this.balance = -snapshot.getBalance().amount();
+    }
+
+    public InterestCheckpoint(DLoan loan) {
+        this.loan = loan;
+        this.principal = loan.getInitialAmount().amount();
+        this.balance = this.principal;
+        this.lastUpdated = loan.getStartDate();
+    }
+
+    public InterestCheckpoint(InterestCheckpoint other) {
+        this.loan = other.loan;
+        this.principal = other.principal;
+        this.balance = other.balance;
+        this.lastUpdated = other.lastUpdated;
+        this.accumulatedInterest = other.accumulatedInterest;
+    }
+
+    public void accumulateInterest(BigDecimal interest, Instant date) {
+        long interestLong = interest.longValue();
+        this.accumulatedInterest += interestLong;
+        updateBalance(interestLong, date);
+    }
+
+    public void updateNegativeBalance(long delta, Instant timestamp) {
+        updateBalance(-delta, timestamp);
+    }
+
+    public long addInterest() {
+        long delta = accumulatedInterest;
+        resetInterest();
+        return delta;
+    }
+
+    public void updateBalance(long delta, Instant date) {
+        this.balance += delta;
+        this.lastUpdated = date;
+        this.principal = Math.min(this.principal, this.balance);
+        this.principal = Math.max(this.principal, 0);
+    }
+
+    public void resetInterest() {
+        this.accumulatedInterest = 0;
+    }
+
+    public long balance() {
+        return balance;
+    }
+
+    public BigDecimal principal() {
+        return BigDecimal.valueOf(principal);
+    }
+
+    public Instant lastUpdated() {
+        return lastUpdated;
+    }
+
+    public long accumulatedInterest() {
+        return accumulatedInterest;
+    }
+
+    public Emeralds interestEmeralds() {
+        return Emeralds.of(accumulatedInterest);
+    }
+
+    public Emeralds balanceEmeralds() {
+        return Emeralds.of(balance);
+    }
+
+    @Override
+    public String toString() {
+        return "InterestCheckpoint{" +
+            "principal=" + Emeralds.of(principal) +
+            ", balance=" + Emeralds.of(balance) +
+            ", lastUpdated=" + lastUpdated +
+            ", accumulatedInterest=" + Emeralds.of(accumulatedInterest) +
+            '}';
+    }
+
+    public DLoan getLoan() {
+        return loan;
+    }
+
+    public void addToPrincipal(long delta) {
+        this.principal += delta;
+    }
+
+    public InterestCheckpoint copy() {
+        return new InterestCheckpoint(this);
+    }
+}

--- a/src/main/java/com/ambrosia/loans/database/account/loan/LoanAccess.java
+++ b/src/main/java/com/ambrosia/loans/database/account/loan/LoanAccess.java
@@ -117,7 +117,7 @@ public interface LoanAccess {
         if (emeralds.isNegative()) throw new IllegalArgumentException("Cannot make negative payment!");
 
         DLoan loan = getEntity();
-        Emeralds totalOwed = loan.getTotalOwed(null, timestamp);
+        Emeralds totalOwed = loan.getTotalOwed(timestamp);
         if (emeralds.gt(totalOwed.amount())) throw new OverpaymentException(emeralds, totalOwed);
 
         DLoanPayment payment = new DLoanPayment(loan, timestamp, emeralds.amount(), staff);
@@ -132,7 +132,7 @@ public interface LoanAccess {
 
         if (loan.isPaid()) {
             Instant adjustmentDate = payment.getDate().plusMillis(1);
-            Emeralds adjustment = loan.getTotalOwed(null, adjustmentDate);
+            Emeralds adjustment = loan.getTotalOwed(adjustmentDate);
             Ambrosia.get().logger().info("Loan is paid on {}. Adjustment is {}.", formatDate(adjustmentDate), adjustment);
             if (!adjustment.isZero()) {
                 AdjustApi.createAdjustment(staff, loan, adjustment, adjustmentDate);

--- a/src/main/java/com/ambrosia/loans/database/account/payment/DLoanPayment.java
+++ b/src/main/java/com/ambrosia/loans/database/account/payment/DLoanPayment.java
@@ -69,7 +69,7 @@ public class DLoanPayment extends Model implements Commentable {
     public void updateSimulation() {
         DClient client = this.loan.getClient();
         client.refresh();
-        client.updateBalance(amount, getDate(), AccountEventType.PAYMENT);
+        client.updateBalance(loan, amount, getDate(), AccountEventType.PAYMENT);
     }
 
     public DLoan getLoan() {

--- a/src/main/java/com/ambrosia/loans/database/entity/client/ClientSearch.java
+++ b/src/main/java/com/ambrosia/loans/database/entity/client/ClientSearch.java
@@ -44,7 +44,8 @@ public class ClientSearch {
 
         List<String> names = Stream.concat(
                 client.getNameHistory().stream()
-                    .map(DNameHistory::getName),
+                    .map(DNameHistory::getName)
+                    .filter(Objects::nonNull),
                 Stream.of(displayName, discord, minecraft)
             ).filter(Objects::nonNull)
             .toList();

--- a/src/main/java/com/ambrosia/loans/database/entity/client/username/DNameHistory.java
+++ b/src/main/java/com/ambrosia/loans/database/entity/client/username/DNameHistory.java
@@ -76,6 +76,7 @@ public class DNameHistory extends Model {
         return client;
     }
 
+    @Nullable
     public String getName() {
         return this.name;
     }

--- a/src/main/java/com/ambrosia/loans/database/system/service/GiveToInvestors.java
+++ b/src/main/java/com/ambrosia/loans/database/system/service/GiveToInvestors.java
@@ -112,10 +112,10 @@ public class GiveToInvestors {
             long adjustment = investor.newlyAdjusted.longValue();
             if (adjustment != 0) {
                 AccountEventType eventType = adjustment > 0 ? AccountEventType.ADJUST_UP : AccountEventType.ADJUST_DOWN;
-                investor.client.updateBalance(adjustment, currentTime, eventType);
+                investor.client.updateBalance(null, adjustment, currentTime, eventType);
             }
             if (amountToInvestor != 0)
-                investor.client.updateBalance(amountToInvestor, currentTime, AccountEventType.PROFIT);
+                investor.client.updateBalance(null, amountToInvestor, currentTime, AccountEventType.PROFIT);
         }
         return amountGiven;
     }

--- a/src/main/java/com/ambrosia/loans/database/system/service/RunBankSimulation.java
+++ b/src/main/java/com/ambrosia/loans/database/system/service/RunBankSimulation.java
@@ -115,7 +115,11 @@ public class RunBankSimulation {
 
     public static void simulate(Instant simulateStartDate) {
         synchronized (RunBankSimulation.SYNC) {
-            simulate(simulateStartDate, SimulationOptions.DEFAULT);
+            try {
+                simulate(simulateStartDate, SimulationOptions.DEFAULT);
+            } catch (Exception e) {
+                DatabaseModule.get().logger().error("", e);
+            }
         }
     }
 

--- a/src/main/java/com/ambrosia/loans/discord/command/manager/bank/BankProfitsPage.java
+++ b/src/main/java/com/ambrosia/loans/discord/command/manager/bank/BankProfitsPage.java
@@ -23,8 +23,6 @@ public class BankProfitsPage extends DCFScrollGuiFixed<BankGui, BankMonthlySnaps
         registerButtons();
         setEntries(parent.queryMonthlyProfits().getBankProfits());
         sort();
-//        entryPage = getMaxPage() - 1;
-//        verifyPageNumber();
     }
 
     @Override

--- a/src/main/java/com/ambrosia/loans/discord/command/player/request/payment/RequestPaymentCommand.java
+++ b/src/main/java/com/ambrosia/loans/discord/command/player/request/payment/RequestPaymentCommand.java
@@ -28,7 +28,7 @@ public class RequestPaymentCommand extends BaseClientSubCommand {
             replyError(event, "You have no active loans!");
             return;
         }
-        Emeralds loanAmount = loan.get().getTotalOwed(null, timestamp);
+        Emeralds loanAmount = loan.get().getTotalOwed(timestamp);
         Emeralds payment;
         Boolean isFull = CommandOption.PAYMENT_FULL.getOptional(event);
         if (isFull != null && isFull) payment = loanAmount;

--- a/src/main/java/com/ambrosia/loans/discord/command/staff/alter/loan/LoanInterestCommand.java
+++ b/src/main/java/com/ambrosia/loans/discord/command/staff/alter/loan/LoanInterestCommand.java
@@ -30,7 +30,7 @@ public class LoanInterestCommand extends BaseStaffSubCommand {
             return;
         }
         Instant date = Instant.now();
-        Emeralds totalOwed = loan.getTotalOwed(null, date);
+        Emeralds totalOwed = loan.getTotalOwed(date);
         Emeralds adjustmentAmount = loan.getAccumulatedInterest().minus(interestCap);
         if (!force && adjustmentAmount.gt(totalOwed.amount())) {
             String msg = "Only %s is owed on loan!".formatted(totalOwed);

--- a/src/main/java/com/ambrosia/loans/discord/command/staff/alter/payment/PaymentMakeCommand.java
+++ b/src/main/java/com/ambrosia/loans/discord/command/staff/alter/payment/PaymentMakeCommand.java
@@ -44,7 +44,7 @@ public class PaymentMakeCommand extends BaseStaffSubCommand {
 
         Instant date = CommandOption.DATE.getOrParseError(event, Instant.now());
         if (date == null) return;
-        Emeralds maxPayment = loan.getTotalOwed(null, date);
+        Emeralds maxPayment = loan.getTotalOwed(date);
 
         boolean isFull = CommandOption.PAYMENT_FULL.getOptional(event, false);
         Emeralds amount = isFull ? maxPayment : CommandOption.PAYMENT_AMOUNT.getOptional(event);

--- a/src/main/java/com/ambrosia/loans/discord/command/staff/alter/withdrawal/AWithdrawalSetCommand.java
+++ b/src/main/java/com/ambrosia/loans/discord/command/staff/alter/withdrawal/AWithdrawalSetCommand.java
@@ -1,16 +1,10 @@
 package com.ambrosia.loans.discord.command.staff.alter.withdrawal;
 
-import com.ambrosia.loans.database.entity.staff.DStaffConductor;
 import com.ambrosia.loans.discord.base.command.staff.BaseStaffCommand;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 
 public class AWithdrawalSetCommand extends BaseStaffCommand {
-
-    @Override
-    protected void onStaffCommand(SlashCommandInteractionEvent event, DStaffConductor staff) {
-    }
 
     @Override
     public SlashCommandData getStaffData() {

--- a/src/main/java/com/ambrosia/loans/discord/request/payment/ActiveRequestPaymentGui.java
+++ b/src/main/java/com/ambrosia/loans/discord/request/payment/ActiveRequestPaymentGui.java
@@ -37,20 +37,13 @@ public class ActiveRequestPaymentGui extends ActiveRequestGui<ActiveRequestPayme
     }
 
     @Override
-    protected List<Field> fields() {
-        String balance = data.getBalance().negative().toString();
-        return List.of(
-        );
+    public MessageCreateData makeMessage() {
+        return addButton(super.makeMessage());
     }
 
     @Override
     public MessageCreateData makeClientMessage(String... extraDescription) {
         return addButton(super.makeClientMessage(extraDescription));
-    }
-
-    @Override
-    public MessageCreateData makeMessage() {
-        return addButton(super.makeMessage());
     }
 
     @Override
@@ -60,7 +53,7 @@ public class ActiveRequestPaymentGui extends ActiveRequestGui<ActiveRequestPayme
         DLoan loan = data.getLoan();
         Instant timestamp = data.getTimestamp();
         Emeralds payment = data.getPayment();
-        Emeralds balance = data.getLoan().getTotalOwed(null, timestamp);
+        Emeralds balance = data.getLoan().getTotalOwed(timestamp);
         Instant startDate = loan.getStartDate();
         embed.appendDescription("**Payment:** %s\n".formatted(payment));
         embed.appendDescription("**Initiated on:** %s\n\n".formatted(formatDate(timestamp)));
@@ -79,10 +72,26 @@ public class ActiveRequestPaymentGui extends ActiveRequestGui<ActiveRequestPayme
         embed.setFooter("%s is the associated staff".formatted(staff), staffIcon);
     }
 
-    private MessageCreateData addButton(MessageCreateData messageCreateData) {
-        MessageCreateBuilder builder = MessageCreateBuilder.from(messageCreateData);
-        builder.addComponents(ActionRow.of(showCollateralBtn(false)));
-        return builder.build();
+    @Override
+    protected String staffCommand() {
+        return "payment";
+    }
+
+    @Override
+    protected String clientCommandName() {
+        return null;
+    }
+
+    @Override
+    protected List<Field> fields() {
+        String balance = data.getBalance().negative().toString();
+        return List.of(
+        );
+    }
+
+    @Override
+    protected String title() {
+        return "Payment %s %s".formatted(data.getPayment(), createEntityId());
     }
 
     @Override
@@ -96,18 +105,9 @@ public class ActiveRequestPaymentGui extends ActiveRequestGui<ActiveRequestPayme
         return page;
     }
 
-    @Override
-    protected String clientCommandName() {
-        return null;
-    }
-
-    @Override
-    protected String staffCommand() {
-        return "payment";
-    }
-
-    @Override
-    protected String title() {
-        return "Payment %s %s".formatted(data.getPayment(), createEntityId());
+    private MessageCreateData addButton(MessageCreateData messageCreateData) {
+        MessageCreateBuilder builder = MessageCreateBuilder.from(messageCreateData);
+        builder.addComponents(ActionRow.of(showCollateralBtn(false)));
+        return builder.build();
     }
 }

--- a/src/main/java/com/ambrosia/loans/migrate/loan/ImportedLoanAdjustment.java
+++ b/src/main/java/com/ambrosia/loans/migrate/loan/ImportedLoanAdjustment.java
@@ -14,16 +14,16 @@ public record ImportedLoanAdjustment(DLoan loan, Instant date, Emeralds amount, 
     public Emeralds getBalanceAt(Instant date) {
         loan.refresh();
         loan.getSections().forEach(Model::refresh);
-        return loan.getTotalOwed(null, date).negative();
-    }
-
-    @Override
-    public long getId() {
-        return 0;
+        return loan.getTotalOwed(date).negative();
     }
 
     @Override
     public void createAdjustment(Emeralds difference, Instant date) {
         AdjustApi.createMigrationAdjustment(loan, difference, client(), date, true);
+    }
+
+    @Override
+    public long getId() {
+        return 0;
     }
 }

--- a/src/main/java/com/ambrosia/loans/service/message/loan/ScheduledLoanMessage.java
+++ b/src/main/java/com/ambrosia/loans/service/message/loan/ScheduledLoanMessage.java
@@ -29,7 +29,7 @@ public class ScheduledLoanMessage extends ScheduledClientMessage<LoanReminderMes
             This is a friendly reminder about your loan from *%s*.
             **Recent activity:**
             - %s
-                        
+
             %s
             """.trim().formatted(formatDate(loan.getStartDate()), lastActivity, nextMessageTime.message());
     }

--- a/src/main/java/com/ambrosia/loans/util/clover/CloverApi.java
+++ b/src/main/java/com/ambrosia/loans/util/clover/CloverApi.java
@@ -40,7 +40,10 @@ public class CloverApi {
         if (!response.isSuccessful())
             return null;
         ResponseBody body = response.body();
-        if (body == null) return null;
+        if (body == null) {
+            Ambrosia.get().logger().error("Response has no body");
+            return null;
+        }
         try (Reader reader = new InputStreamReader(body.byteStream(), StandardCharsets.ISO_8859_1)) {
             return gson().fromJson(reader, PlayerTermsResponse.class);
         }


### PR DESCRIPTION
- [Bug[ Overlapping loans would trigger interest for the total balance --- Fixed by only adding @ManyToOne relation from client_loan_snapshot to loan, which tracks interest on a per-loan basis.
- [Bug] Adjustments were not included as timesteps in interest rounding --- Fixed by adding InterestCheckpoint object and rewriting DLoan#getInterest, DLoan#getExactInterest, DLoan#getSimpleInterest